### PR TITLE
Return error with HTTP statusCode for webSocket if available

### DIFF
--- a/Sources/SignalRClient/WebsocketsTransport.swift
+++ b/Sources/SignalRClient/WebsocketsTransport.swift
@@ -112,7 +112,7 @@ public class WebsocketsTransport: NSObject, Transport, URLSessionWebSocketDelega
 
         let statusCode = (webSocketTask?.response as? HTTPURLResponse)?.statusCode ?? -1
         logger.log(logLevel: .info, message: "Error starting webSocket. Error: \(error!), HttpStatusCode: \(statusCode), WebSocket closeCode: \(webSocketTask?.closeCode.rawValue ?? -1)")
-        delegate?.transportDidClose(error)
+        delegate?.transportDidClose((statusCode != -1 && statusCode != 200) ? SignalRError.webError(statusCode: statusCode) : error)
         shutdownTransport()
     }
 

--- a/Tests/SignalRClientTests/HttpConnectionTests.swift
+++ b/Tests/SignalRClientTests/HttpConnectionTests.swift
@@ -528,7 +528,7 @@ class HttpConnectionTests: XCTestCase {
 
         let connectionDelegate = TestConnectionDelegate()
         connectionDelegate.connectionDidFailToOpenHandler = { error in
-            XCTAssertTrue("\(error)".contains("Code=-1011"))
+            XCTAssertEqual("\(SignalRError.webError(statusCode: 404))", "\(error)")
             didFailToOpenExpectation.fulfill()
         }
         httpConnection.delegate = connectionDelegate


### PR DESCRIPTION
If a webSocket transport cannot be started due to an error, return the SignalRError.webError with HTTP status code which is more useful than the generic NSURLErrorDomain Code=-1011 "There was a bad response from the server."