### PR TITLE
Handles informational HTTP status codes

### DIFF
--- a/Sources/SignalRClient/LongPollingTransport.swift
+++ b/Sources/SignalRClient/LongPollingTransport.swift
@@ -49,6 +49,8 @@ public class LongPollingTransport: Transport {
             } else if let response = responseOptional {
                 if response.statusCode == 200 {
                     sendDidComplete(nil)
+                } else if (100...199).contains(response.statusCode) {
+                    sendDidComplete(nil)
                 } else {
                     sendDidComplete(SignalRError.webError(statusCode: response.statusCode))
                 }

--- a/Sources/SignalRClient/WebsocketsTransport.swift
+++ b/Sources/SignalRClient/WebsocketsTransport.swift
@@ -117,7 +117,11 @@ public class WebsocketsTransport: NSObject, Transport, URLSessionWebSocketDelega
 
         let statusCode = (webSocketTask?.response as? HTTPURLResponse)?.statusCode ?? -1
         logger.log(logLevel: .info, message: "Error starting webSocket. Error: \(error!), HttpStatusCode: \(statusCode), WebSocket closeCode: \(webSocketTask?.closeCode.rawValue ?? -1)")
-        delegate?.transportDidClose((statusCode != -1 && statusCode != 200) ? SignalRError.webError(statusCode: statusCode) : error)
+        if statusCode != -1 && statusCode != 200 && (100...199).contains(statusCode)  {
+            delegate?.transportDidClose(error)
+        } else {
+            delegate?.transportDidClose(SignalRError.webError(statusCode: statusCode))
+        }
         shutdownTransport()
     }
 


### PR DESCRIPTION
Ensures the SignalR client correctly handles informational HTTP status codes (100-199) in negotiate responses, long polling, and WebSocket connections.

Previously, these codes were not explicitly handled, leading to potential issues in certain server configurations. Now, the client logs these codes for debugging purposes and proceeds without error, aligning with expected behavior.
