### PR TITLE
Adds connection state and delegate separation

### DIFF
--- a/Sources/SignalRClient/Connection.swift
+++ b/Sources/SignalRClient/Connection.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public protocol Connection {
+    var state: HttpConnection.State { get }
     var delegate: ConnectionDelegate? { get set }
     var inherentKeepAlive: Bool { get }
     var connectionId: String? { get }

--- a/Sources/SignalRClient/ConnectionDelegate.swift
+++ b/Sources/SignalRClient/ConnectionDelegate.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 public protocol ConnectionDelegate: AnyObject {
-    func connectionDidOpen(connection: Connection)
+    func transportConnectionDidOpen(connection: Connection)
+    func hubConnectionDidOpen(connection: Connection)
     func connectionDidFailToOpen(error: Error)
     func connectionDidReceiveData(connection: Connection, data: Data)
     func connectionDidClose(error: Error?)

--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -8,7 +8,15 @@
 
 import Foundation
 
+
 public class HttpConnection: Connection {
+    public enum State: String {
+        case initial = "initial"
+        case connecting = "connecting"
+        case connected = "connected"
+        case stopped = "stopped"
+    }
+
     private let connectionQueue: DispatchQueue
     private let startDispatchGroup: DispatchGroup
 
@@ -19,7 +27,7 @@ public class HttpConnection: Connection {
 
     private var transportDelegate: TransportDelegate?
 
-    private var state: State
+    public var state: State
     private var transport: Transport?
     private var stopError: Error?
 
@@ -29,12 +37,7 @@ public class HttpConnection: Connection {
         return transport?.inherentKeepAlive ?? true
     }
 
-    private enum State: String {
-        case initial = "initial"
-        case connecting = "connecting"
-        case connected = "connected"
-        case stopped = "stopped"
-    }
+   
 
     public convenience init(url: URL, options: HttpConnectionOptions = HttpConnectionOptions(), logger: Logger = NullLogger()) {
         self.init(url: url, options: options, transportFactory: DefaultTransportFactory(logger: logger), logger: logger)
@@ -247,7 +250,7 @@ public class HttpConnection: Connection {
             self.connectionId = connectionId
             options.callbackQueue.async { [weak self] in
                 guard let self else { return }
-                self.delegate?.connectionDidOpen(connection: self)
+                self.delegate?.transportConnectionDidOpen(connection: self)
             }
         } else {
             logger.log(logLevel: .debug, message: "Connection is being stopped while the transport is starting")

--- a/Sources/SignalRClient/HubConnectionDelegate.swift
+++ b/Sources/SignalRClient/HubConnectionDelegate.swift
@@ -22,39 +22,39 @@ public protocol HubConnectionDelegate: AnyObject {
 
      - parameter hubConnection: the newly opened `HubConnection`
     */
-    func connectionDidOpen(hubConnection: HubConnection)
+    func hubConnectionDidOpen(hubConnection: HubConnection)
 
     /**
      Invoked when the connection to the server failed to open.
 
      - parameter error: contains failure details
     */
-    func connectionDidFailToOpen(error: Error)
+    func hubConnectionDidFailToOpen(error: Error)
 
     /**
      Invoked when the connection to the server was closed.
 
      - parameter error: If the connection was closed cleanly `nil`. Otherwise contains failure detais
     */
-    func connectionDidClose(error: Error?)
+    func hubConnectionDidClose(error: Error?)
 
     /**
      Invoked when the connection will try to reconnect.
 
      - parameter error: Contains the reason for reconnect
     */
-    func connectionWillReconnect(error: Error)
+    func hubConnectionWillReconnect(error: Error)
 
     /**
      Invoked when the connection reconnected successfully.
     */
-    func connectionDidReconnect()
+    func hubConnectionDidReconnect()
     
     func currentReconnectionAttempt(currentAttempt: Int)
 }
 
 public extension HubConnectionDelegate {
-    func connectionWillReconnect(error: Error) {}
-    func connectionDidReconnect() {}
+    func hubConnectionWillReconnect(error: Error) {}
+    func hubConnectionDidReconnect() {}
     
 }


### PR DESCRIPTION
Introduces a connection state to track the connection lifecycle.

Splits the connection delegate methods to differentiate between transport and hub connection events, allowing for more granular event handling.
